### PR TITLE
Backend consolidation

### DIFF
--- a/backend/open_webui/test/apps/webui/pii/test_consolidation.py
+++ b/backend/open_webui/test/apps/webui/pii/test_consolidation.py
@@ -1,15 +1,36 @@
-import pytest
 import json
-from open_webui.test.util.mock_user import mock_webui_user
-from open_webui.utils.pii import consolidate_pii_data, text_masking
+from open_webui.utils.pii import consolidate_pii_data, text_masking, set_file_entity_ids
 
-
-def test_consolidate_pii_data_basic():
-    """Test basic PII consolidation functionality - same text, different ID"""
+def test_set_file_entity_ids():
+    """Test set file entity ids functionality - set id from known entities or next free id"""
     known_entities = [
-        {"id": 1, "label": "PERSON_1", "name": "John Doe"},
+        {"id": 1, "label": "PERSON_1", "name": "john doe"},
         {"id": 2, "label": "EMAIL_1", "name": "john@example.com"},
     ]
+    file_entities_dict = {
+        "jane smith": {"id": 1, "label": "PERSON_1", "text": "jane smith", "type": "PERSON", "occurrences": [{"start_idx": 0, "end_idx": 8}], "raw_text": "Jane Smith"}, 
+        "john doe": {"id": 2, "label": "PERSON_2", "text": "john doe", "type": "PERSON", "occurrences": [{"start_idx": 10, "end_idx": 18}], "raw_text": "John Doe"}, 
+    }
+    result = set_file_entity_ids(file_entities_dict, known_entities)
+    assert len(result) == 2
+    assert result['jane smith']['id'] == 3  # changed to next 'free' id
+    assert result['jane smith']['label'] == "PERSON_3"
+    assert result['jane smith']['raw_text'] == "Jane Smith"
+    assert result['jane smith']['text'] == "jane smith"
+    assert result['jane smith']['type'] == "PERSON"
+    assert result['jane smith']['occurrences'] == [{"start_idx": 0, "end_idx": 8}]
+    assert result['john doe']['id'] == 1  # set id from known entities
+    assert result['john doe']['label'] == "PERSON_1"
+    assert result['john doe']['raw_text'] == "John Doe"
+    assert result['john doe']['text'] == "john doe"
+    assert result['john doe']['type'] == "PERSON"
+    assert result['john doe']['occurrences'] == [{"start_idx": 10, "end_idx": 18}]
+
+def test_consolidate_pii_data_basic():
+    """
+    Test basic PII consolidation functionality - same text, different ID
+    file_entities_dict is already consolidated
+    """
 
     pii_data = [
         {
@@ -30,35 +51,39 @@ def test_consolidate_pii_data_basic():
         },
     ]
 
-    result = consolidate_pii_data(known_entities, pii_data)
+    file_entities_dict = {
+        "john doe": {
+            "text": "john doe",
+            "label": "PERSON_1",
+            "type": "PERSON",
+            "occurrences": [{"start_idx": 0, "end_idx": 8}],
+            "id": 1,
+            "raw_text": "John Doe",
+        },
+        "john@example.com": {
+            "text": "john@example.com",
+            "label": "EMAIL_2",
+            "type": "EMAIL",
+            "occurrences": [{"start_idx": 10, "end_idx": 25}],
+            "id": 2,
+            "raw_text": "john@example.com",
+        },
+        "ACME Inc.": {
+            "text": "ACME Inc.",
+            "label": "ORGANIZATION_3",
+            "type": "ORGANIZATION",
+            "occurrences": [{"start_idx": 26, "end_idx": 34}],
+            "id": 3,
+            "raw_text": "ACME Inc.",
+        },
+    } 
+
+    result = consolidate_pii_data(pii_data, file_entities_dict)
 
     # Check that IDs are properly assigned
     assert len(result) == 2
     assert result[0]["id"] == 1  # John Doe should get ID 1
     assert result[1]["id"] == 2  # john@example.com should get ID 2
-
-
-def test_consolidate_pii_data_no_match():
-    """Test consolidation when no matches are found"""
-    known_entities = [{"id": 1, "label": "PERSON_1", "name": "John Doe"}]
-
-    pii_data = [
-        {
-            "text": "jane smith",
-            "label": "PERSON_3",
-            "type": "PERSON",
-            "occurrences": [{"start_idx": 0, "end_idx": 10}],
-            "id": 3,
-            "raw_text": "Jane Smith",
-        }
-    ]
-
-    result = consolidate_pii_data(known_entities, pii_data)
-
-    # Should return original data without ID assignment
-    assert len(result) == 1
-    assert result[0]["id"] == 3
-
 
 def test_text_masking_basic():
     """Test basic text masking functionality"""
@@ -163,56 +188,18 @@ def test_pii_data_parsing_from_metadata():
 
 def test_consolidation_with_empty_data():
     """Test consolidation with empty or invalid data"""
-    # Empty known entities
-    result = consolidate_pii_data(
-        [],
-        [
-            {
-                "text": "John Doe",
-                "type": "PERSON",
-                "occurrences": [{"start_idx": 0, "end_idx": 8}],
-                "id": 1,
-            }
-        ],
-    )
-    assert len(result) == 1
-    assert result[0]["id"] == 1
-
     # Empty PII data
-    result = consolidate_pii_data([{"id": 1, "name": "John Doe"}], [])
+    result = consolidate_pii_data([], {})
     assert len(result) == 0
 
 
-def test_consolidate_ids():
-    """Test consolidation of IDs - not matching text"""
-    known_entities = [
-        {"id": 1, "label": "PERSON_1", "name": "John McDowell"},
-        {"id": 2, "label": "EMAIL_1", "name": "mcdowell@example.com"},
-    ]
-
-    pii_data = [
-        {
-            "id": 1,
-            "label": "PERSON_1",
-            "text": "john doe",
-            "type": "PERSON",
-            "occurrences": [{"start_idx": 0, "end_idx": 8}],
-            "raw_text": "John Doe",
-        },
-        {
-            "id": 2,
-            "label": "EMAIL_2",
-            "text": "john@example.com",
-            "type": "EMAIL",
-            "occurrences": [{"start_idx": 10, "end_idx": 25}],
-            "raw_text": "john@example.com",
-        },
-    ]
-
-    result = consolidate_pii_data(known_entities, pii_data)
-
-    # Check that IDs are properly assigned
-    assert len(result) == 2
-    ids = [item["id"] for item in result]
-    assert len(ids) == 2
-    assert set(ids) == {3, 4}
+def test_set_file_entity_ids_with_empty_known_entities():
+    """Test set file entity ids with empty known entities"""
+    known_entities = []
+    file_entities_dict = {"john doe": {"id": 2, "label": "PERSON_2", "text": "john doe", "type": "PERSON", "occurrences": [{"start_idx": 0, "end_idx": 8}]}}
+    result = set_file_entity_ids(file_entities_dict, known_entities)
+    assert len(result) == 1
+    assert result["john doe"]["id"] == 1
+    assert result["john doe"]["label"] == "PERSON_1"
+    assert result["john doe"]["type"] == "PERSON"
+    assert result["john doe"]["occurrences"] == [{"start_idx": 0, "end_idx": 8}]


### PR DESCRIPTION
New logic:
1. Consolidate all file PII data, use ids/types from `known_entities` if available, use next free unique id otherwise
2. Overwrite file chunk PIIs with consolidated global file PIIs

* adjusted backend tests